### PR TITLE
Found a bug in soil_request_filter()

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -207,7 +207,7 @@ add_filter('get_bloginfo_rss', 'soil_remove_default_description');
  * @link http://core.trac.wordpress.org/ticket/11330
  */
 function soil_request_filter($query_vars) {
-  if (isset($_GET['s']) && empty($_GET['s'])) {
+  if (isset($_GET['s']) && empty($_GET['s']) && !is_admin()) {
     $query_vars['s'] = ' ';
   }
 


### PR DESCRIPTION
This function affects the dashboard as well and breaks product filtering in WooCommerce 2.15 (not sure what other versions). Adding && !is_admin() should fix it.
