### PR TITLE
Bootstrap responsive embeds

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -112,13 +112,13 @@ function soil_body_class($classes) {
 add_filter('body_class', 'soil_body_class');
 
 /**
- * Wrap embedded media as suggested by Readability
+ * Wrap embedded media using Bootstrap responsive embeds
  *
- * @link https://gist.github.com/965956
- * @link http://www.readability.com/publishers/guidelines#publisher
+ * @link http://getbootstrap.com/components/#responsive-embed
  */
 function soil_embed_wrap($cache, $url, $attr = '', $post_ID = '') {
-  return '<div class="entry-content-asset">' . $cache . '</div>';
+  $cache = str_replace('<iframe', '<iframe class="embed-responsive-item"', $cache);
+  return '<div class="embed-responsive embed-responsive-16by9">' . $cache . '</div>';
 }
 add_filter('embed_oembed_html', 'soil_embed_wrap', 10, 4);
 


### PR DESCRIPTION
Bootstrap 3.2.0 now has responsive embed support, so I've replaced Readability's markup with Bootstraps. With this change there's no longer any need for custom CSS or plugins like fitvids to do responsive embeds :)

http://getbootstrap.com/components/#responsive-embed
