### PR TITLE
Remove version query strings from all assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ Enable Soil's nice search (`/search/query/`) with:
 ```php
 add_theme_support('soil-nice-search');
 ```
+
+### Disable Asset Versioning
+
+Disable `ver` query string from all styles and scripts with:
+
+```php
+add_theme_support('soil-disable-asset-versioning');
+```

--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -206,12 +206,3 @@ function soil_request_filter($query_vars) {
   return $query_vars;
 }
 add_filter('request', 'soil_request_filter');
-
-/**
- * Remove version query string from all styles and scripts
- */
-function soil_remove_script_version($src){
-  return remove_query_arg('ver', $src);
-}
-add_filter('script_loader_src', 'soil_remove_script_version', 15, 1);
-add_filter('style_loader_src', 'soil_remove_script_version', 15, 1);

--- a/modules/disable-asset-versioning.php
+++ b/modules/disable-asset-versioning.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Remove version query string from all styles and scripts
+ *
+ * You can enable/disable this feature in functions.php (or lib/config.php if you're using Roots):
+ * add_theme_support('soil-disable-asset-versioning');
+ */
+function soil_remove_script_version($src){
+  return remove_query_arg('ver', $src);
+}
+add_filter('script_loader_src', 'soil_remove_script_version', 15, 1);
+add_filter('style_loader_src', 'soil_remove_script_version', 15, 1);

--- a/soil.php
+++ b/soil.php
@@ -25,5 +25,9 @@ function soil_load_modules() {
   if (current_theme_supports('soil-nice-search')) {
     require_once(SOIL_PATH . 'modules/nice-search.php');
   }
+
+  if (current_theme_supports('soil-disable-asset-versioning')) {
+    require_once(SOIL_PATH . 'modules/disable-asset-versioning.php');
+  }
 }
 add_action('after_setup_theme', 'soil_load_modules');


### PR DESCRIPTION
PageSpeed recommends removing query strings from all static resources

> Most proxies, most notably Squid up through version 3.0, do not cache resources with a "?" in their URL. To enable proxy caching for these resources, remove query strings from references to static resources, and instead encode the parameters into the file names themselves.

This commit make sure all assets have the `ver` query string stripped.
