### PR TITLE
remove extra 10px of width added by WP to captions

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -149,7 +149,7 @@ function soil_caption($output, $attr, $content) {
   // Set up the attributes for the caption <figure>
   $attributes  = (!empty($attr['id']) ? ' id="' . esc_attr($attr['id']) . '"' : '' );
   $attributes .= ' class="wp-caption ' . esc_attr($attr['align']) . '"';
-  $attributes .= ' style="width: ' . (esc_attr($attr['width']) + 10) . 'px"';
+  $attributes .= ' style="width: ' . esc_attr($attr['width']) . 'px"';
 
   $output  = '<figure' . $attributes .'>';
   $output .= do_shortcode($content);


### PR DESCRIPTION
The extra 10px of width that Wordpress adds to the caption box is not needed and problematic when you are trying to do captions that do not have a "box" layout. Strip out the 10px to remove this WordPress annoyance. Folks can add their own styling when needed.
