### PR TITLE
Remove soil_caption. Use WP native HTML5 markup for captions instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ add_theme_support('soil-clean-up');
 * Clean up `<link>` tags
 * Clean up `body_class()`
 * Wrap embedded media as suggested by Readability
-* Use `<figure>` and `<figcaption>` for WP captions
 * Remove unnecessary dashboard widgets
 * Remove unnecessary self-closing tags
 

--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -123,44 +123,6 @@ function soil_embed_wrap($cache, $url, $attr = '', $post_ID = '') {
 add_filter('embed_oembed_html', 'soil_embed_wrap', 10, 4);
 
 /**
- * Use <figure> and <figcaption> for captions
- *
- * @link http://justintadlock.com/archives/2011/07/01/captions-in-wordpress
- */
-function soil_caption($output, $attr, $content) {
-  if (is_feed()) {
-    return $output;
-  }
-
-  $defaults = array(
-    'id'      => '',
-    'align'   => 'alignnone',
-    'width'   => '',
-    'caption' => ''
-  );
-
-  $attr = shortcode_atts($defaults, $attr);
-
-  // If the width is less than 1 or there is no caption, return the content wrapped between the [caption] tags
-  if ($attr['width'] < 1 || empty($attr['caption'])) {
-    return $content;
-  }
-
-  // Set up the attributes for the caption <figure>
-  $attributes  = (!empty($attr['id']) ? ' id="' . esc_attr($attr['id']) . '"' : '' );
-  $attributes .= ' class="wp-caption ' . esc_attr($attr['align']) . '"';
-  $attributes .= ' style="width: ' . esc_attr($attr['width']) . 'px"';
-
-  $output  = '<figure' . $attributes .'>';
-  $output .= do_shortcode($content);
-  $output .= '<figcaption class="caption wp-caption-text">' . $attr['caption'] . '</figcaption>';
-  $output .= '</figure>';
-
-  return $output;
-}
-add_filter('img_caption_shortcode', 'soil_caption', 10, 3);
-
-/**
  * Remove unnecessary dashboard widgets
  *
  * @link http://www.deluxeblogtips.com/2011/01/remove-dashboard-widgets-in-wordpress.html


### PR DESCRIPTION
Wordpress already supports HTML markup for captions via `add_theme_support('html5', array('caption'))`. This commit removes the custom caption shortcode filter in Soil

This pull request is associated with a [Roots pull request](https://github.com/roots/roots/pull/1105) that adds in HTML5 captions via `add_theme_support` and applies the caption padding styles from Bootstrap via LESS.
