### PR TITLE
Add RSD link

### DIFF
--- a/modules/disable-trackbacks.php
+++ b/modules/disable-trackbacks.php
@@ -49,12 +49,6 @@ function soil_kill_pingback_url($output, $show) {
   return $output;
 }
 add_filter('bloginfo_url', 'soil_kill_pingback_url', 10, 2);
-
-/**
- * hijack options updating for XMLRPC
- */
-add_filter('pre_update_option_enable_xmlrpc', '__return_false');
-add_filter('pre_option_enable_xmlrpc', '__return_zero');
  
 /**
  * Disable XMLRPC call


### PR DESCRIPTION
Removing the RSD link causes the WordPress mobile app for iOS and Android to be unable to connect to self-hosted sites. Deleting the action that removes the RSD link fixes the connect issue.
