### PR TITLE
Don't lose additional query string arguments on redirect

### DIFF
--- a/modules/nice-search.php
+++ b/modules/nice-search.php
@@ -3,7 +3,7 @@
  * Redirects search results from /?s=query to /search/query/, converts %20 to +
  *
  * @link http://txfx.net/wordpress-plugins/nice-search/
- * 
+ *
  * You can enable/disable this feature in functions.php (or lib/config.php if you're using Roots):
  * add_theme_support('soil-nice-search');
  */
@@ -15,7 +15,17 @@ function soil_nice_search_redirect() {
 
   $search_base = $wp_rewrite->search_base;
   if (is_search() && !is_admin() && strpos($_SERVER['REQUEST_URI'], "/{$search_base}/") === false) {
-    wp_redirect(home_url("/{$search_base}/" . urlencode(get_query_var('s'))));
+
+    // Parse and retain any additional query string arguments:
+    $qs = array();
+    parse_str( $_SERVER['QUERY_STRING'], $qs );
+    unset( $qs['s'] );
+
+    $s     = urlencode( get_query_var( 's' ) );
+    $query = empty( $qs ) ? '' : sprintf( '?%s', http_build_query( $qs ) );
+    $url   = home_url( sprintf( '/%s/%s%s', $search_base, $s, $query ) );
+
+    wp_redirect( $url );
     exit();
   }
 }


### PR DESCRIPTION
The nicer search module currently discards all additional query string arguments on redirect. This patch should fix that, so that links like `/?s=query&post_type=cpt` get changed to `/search/query?post_type=cpt`.