### PR TITLE
Add page template class to body tag

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -94,9 +94,10 @@ add_filter('style_loader_tag', 'soil_clean_style_tag');
  * Add and remove body_class() classes
  */
 function soil_body_class($classes) {
-  // Add post/page slug
+  // Add post/page slug and template slug
   if (is_single() || is_page() && !is_front_page()) {
     $classes[] = basename(get_permalink());
+    $classes[] = str_replace('.php', '', basename(get_page_template()));
   }
 
   // Remove unnecessary classes


### PR DESCRIPTION
This PR stems from a discussion around a [similar proposed PR](https://github.com/roots/roots/pull/1229) on roots.

This PR enhances the `soil_body_class` function to add a class based on the page template used. This allows for cleaner CSS and, if using roots, a cleaner selector when implementing template specific Javascript in the DOM-Routing methods used by Roots. 

Please refer to the above mentioned Closed PR for a more in-depth discussion as to the merits of this PR. 