### PR TITLE
Enhancement: Add DNS Prefetch feature

### DIFF
--- a/modules/dns-prefetch-external-assets.php
+++ b/modules/dns-prefetch-external-assets.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Add DNS prefetching for any external assets that are enqueued via 
+ * wp_enqueue_script and wp_enqueue_style
+ * 
+ * You can enable/disable this feature in functions.php (or lib/config.php if you're using Roots):
+ * add_theme_support('soil-dns-prefetch-external-assets');
+ */
+
+function soil_add_dns_prefetch() {
+  global $wp_scripts, $wp_styles;
+  
+  // scripts
+  foreach ( $wp_scripts -> registered as $registered )
+    $script_urls[ $registered -> handle ] = $registered -> src;
+  // styles
+  foreach ( $wp_styles -> registered as $registered )
+    $style_urls[ $registered -> handle ] = $registered -> src;
+  
+  $handles = array_merge( $wp_scripts -> queue, $wp_styles -> queue );
+  array_values( $handles );
+
+  // output of values
+  $output = '';
+  $host = parse_url(site_url(), PHP_URL_HOST);
+  foreach ( $handles as $handle ) {
+    if ( ! empty( $script_urls[ $handle ] ) ) {
+      if (parse_url($script_urls[ $handle ], PHP_URL_HOST) != $host)
+        $output .= '<link rel="dns-prefetch" href="//' . parse_url($script_urls[ $handle ], PHP_URL_HOST) . '">';
+    }
+      
+    if ( ! empty( $style_urls[ $handle ] ) ) {
+      if (parse_url($style_urls[ $handle ], PHP_URL_HOST) != $host)
+        $output .= '<link rel="dns-prefetch" href="//' . parse_url($style_urls[ $handle ], PHP_URL_HOST) . '">';
+    }
+  }
+  
+  echo $output;
+}
+add_action('wp_head', 'soil_add_dns_prefetch', 1, 1);

--- a/soil.php
+++ b/soil.php
@@ -29,5 +29,9 @@ function soil_load_modules() {
   if (current_theme_supports('soil-disable-trackbacks')) {
     require_once(SOIL_PATH . 'modules/disable-trackbacks.php');
   }
+
+  if (current_theme_supports('soil-dns-prefetch-external-assets')) {
+    require_once(SOIL_PATH . 'modules/dns-prefetch-external-assets.php');
+  }
 }
 add_action('after_setup_theme', 'soil_load_modules');


### PR DESCRIPTION
addresses #37 
## DNS Prefetch for External Sources

This enhancement adds a new Soil feature which looks at all enqueued scripts and styles, comparing them to the site url, and adds explicit DNS Prefetch Link to head if it doesn't match. 

https://github.com/h5bp/html5-boilerplate/blob/master/dist/doc/extend.md#dns-prefetching

The only thing I was unable to achieve, according to the linked documentation from h5bp, was inserting this after charset Meta. If anyone knows of a way to achieve this I would be happy to make adjustments. 

I have not thoroughly tested this patch against a full fledged install yet, but it does work on a clean Roots install, only adding a link for the external jQuery. 

It is enabled with `add_theme_support('soil-dns-prefetch-external-assets')` as per the Soil pattern.
