### PR TITLE
Clean up output of <script> tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Clean up output of `<script>` tags
 * Add namespace
 * Disable relative URLs on sitemaps
 * Use `term_link` instead of `tag_link` for relative URLs

--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -93,6 +93,15 @@ function clean_style_tag($input) {
 add_filter('style_loader_tag', __NAMESPACE__ . '\\clean_style_tag');
 
 /**
+ * Clean up output of <script> tags
+ */
+function clean_script_tag($input) {
+  $input = str_replace("type='text/javascript' ", '', $input);
+  return str_replace("'", '"', $input);
+}
+add_filter('script_loader_tag', __NAMESPACE__ . '\\clean_script_tag');
+
+/**
  * Add and remove body_class() classes
  */
 function body_class($classes) {


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/13592 landed in WP 4.1, so we can now clean up `<script>` similar to how we clean up `<link>`

Before: `<script type='text/javascript' src='http://example.com/example.js'></script>`
After:  `<script src="http://example.com/example.js"></script>`