### PR TITLE
Remove fix for empty search queries redirecting to home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Remove fix for empty search queries redirecting to home page
 * Clean up output of `<script>` tags
 * Add namespace
 * Disable relative URLs on sitemaps

--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -167,18 +167,3 @@ function remove_default_description($bloginfo) {
   return ($bloginfo === $default_tagline) ? '' : $bloginfo;
 }
 add_filter('get_bloginfo_rss', __NAMESPACE__ . '\\remove_default_description');
-
-/**
- * Fix for empty search queries redirecting to home page
- *
- * @link http://wordpress.org/support/topic/blank-search-sends-you-to-the-homepage#post-1772565
- * @link http://core.trac.wordpress.org/ticket/11330
- */
-function request_filter($query_vars) {
-  if (isset($_GET['s']) && empty($_GET['s']) && !is_admin()) {
-    $query_vars['s'] = ' ';
-  }
-
-  return $query_vars;
-}
-add_filter('request', __NAMESPACE__ . '\\request_filter');


### PR DESCRIPTION
After 5 years, this was finally fixed in core.

See https://core.trac.wordpress.org/ticket/11330