### PR TITLE
Check for protocol relative URLs we can drop the domain from

### DIFF
--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -12,7 +12,7 @@ namespace Roots\Soil\RelativeURLs;
  * add_theme_support('soil-relative-urls');
  */
 function root_relative_url($input) {
-  preg_match('|https?://([^/]+)(/.*)|i', $input, $matches);
+  preg_match('|(?:https?:)?//([^/]+)(/.*)|i', $input, $matches);
 
   if (!isset($matches[1]) || !isset($matches[2])) {
     return $input;


### PR DESCRIPTION
Changes protocol relative URLs to root relative URLs. Useful for lots of plugins such as WooCommerce that are enqueuing resources that are protocol relative.