### PR TITLE
Filter wp_get_attachment_url for root relative URLs on post thumbnails

### DIFF
--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -33,6 +33,7 @@ if (enable_root_relative_urls()) {
     'the_permalink',
     'wp_list_pages',
     'wp_list_categories',
+    'wp_get_attachment_url',
     'the_content_more_link',
     'the_tags',
     'get_pagenum_link',


### PR DESCRIPTION
Filter attachment URLs to make get_the_post_thumbnail(), the_post_thumbnail() etc. root relative.