### PR TITLE
Add options for Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,24 @@ add_theme_support('soil-nice-search');
 Enable HTML5 Boilerplate's Google Analytics snippet
 
 ```php
-add_theme_support('soil-google-analytics');
-define('GOOGLE_ANALYTICS_ID', 'UA-XXXXXX');
+add_theme_support('soil-google-analytics', 'UA-XXXXX-Y');
 ```
 
-By default, the GA snippet will only be shown for non-administrators. Administrators will get a dummy `ga()` function that writes its arguments to the console log for testing and development purposes. If you define `WP_ENV`, then non-production environments will always get dummy `ga()` function. You can override this via the `soil/displayGA` filter.
+By default, the script will be loaded from the `wp_footer` hook, but you can specify any other action hook as the third parameter.
 
 ```php
-add_filter('soil/displayGA', '__return_true'); // Appends H5BP's GA snippet
-add_filter('soil/displayGA', '__return_false'); // Appends a dummy `ga()` function that writes arguments to console log
+add_theme_support('soil-google-analytics', 'UA-XXXXX-Y', 'wp_head'); // script will load during wp_head
+```
+
+#### Dummy `ga()` Function
+
+This module will load a dummy `ga()` function for non-administrators as well as in non-`production` environments (when `WP_ENV` is defined). The function takes all arguments passed to it and logs them to the JavaScript console.
+
+You can override whether the dummy function is displayed via the `soil/dummyGA` filter.
+
+```php
+add_filter('soil/dummyGA', '__return_true');  // Appends a dummy `ga()` function
+add_filter('soil/dummyGA', '__return_false'); // Appends H5BP's GA snippet
 ```
 
 ### JS to Footer

--- a/modules/google-analytics.php
+++ b/modules/google-analytics.php
@@ -7,27 +7,38 @@ namespace Roots\Soil\GoogleAnalytics;
  *
  * Cookie domain is 'auto' configured. See: http://goo.gl/VUCHKM
  * You can enable/disable this feature in functions.php (or lib/config.php if you're using Sage):
- * add_theme_support('soil-google-analytics');
- * define('GOOGLE_ANALYTICS_ID', 'UA-XXXXXX');
+ * add_theme_support('soil-google-analytics', 'UA-XXXXX-Y', 'wp_footer');
  */
-function google_analytics() {
-  if (!defined('GOOGLE_ANALYTICS_ID') || !GOOGLE_ANALYTICS_ID) {
-    return;
-  }
-  $displayGA = (!defined('WP_ENV') || WP_ENV === 'production') && !current_user_can('manage_options');
+function load_script() {
+  $gaID = options('gaID');
+  if (!$gaID) { return; }
+  $dummyGA = (defined('WP_ENV') && WP_ENV !== 'production') || current_user_can('manage_options');
   ?>
   <script>
-    <?php if (apply_filters('soil/displayGA', $displayGA)) : ?>
-      (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-        function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-        e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-        e.src='//www.google-analytics.com/analytics.js';
-        r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-    <?php else : ?>
+    <?php if (apply_filters('soil/dummyGA', $dummyGA)) : ?>
       function ga() {if (window.console) {console.log('Google Analytics: ' + [].slice.call(arguments));}}
+    <?php else : ?>
+      (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
+      function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
+      e=o.createElement(i);r=o.getElementsByTagName(i)[0];
+      e.src='//www.google-analytics.com/analytics.js';
+      r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
     <?php endif; ?>
-      ga('create','<?= GOOGLE_ANALYTICS_ID; ?>','auto');ga('send','pageview');
+    ga('create','<?= $gaID; ?>','auto');ga('send','pageview');
   </script>
-  <?php
+<?php
 }
-add_action('wp_footer', __NAMESPACE__ . '\\google_analytics', 20);
+
+function options($option = null) {
+  static $options;
+  if (!isset($options)) {
+    $options = \Roots\Soil\Options::getByFile(__FILE__) + ['', 'wp_footer'];
+    $options['gaID'] = &$options[0];
+    $options['hook'] = &$options[1];
+  }
+  return is_null($option) ? $options : $options[$option];
+}
+
+$hook = options('hook');
+
+add_action($hook, __NAMESPACE__ . '\\load_script', 20);

--- a/soil.php
+++ b/soil.php
@@ -14,8 +14,11 @@ License URI:        http://opensource.org/licenses/MIT
 namespace Roots\Soil;
 
 function load_modules() {
+  global $_wp_theme_features;
   foreach (glob(__DIR__ . '/modules/*.php') as $file) {
-    if (current_theme_supports('soil-' . basename($file, '.php'))) {
+    $feature = 'soil-' . basename($file, '.php');
+    if (isset($_wp_theme_features[$feature])) {
+      $options = (array) $_wp_theme_features[$feature];
       require_once $file;
     }
   }

--- a/soil.php
+++ b/soil.php
@@ -13,12 +13,49 @@ License URI:        http://opensource.org/licenses/MIT
 
 namespace Roots\Soil;
 
+class Options {
+  protected static $modules = [];
+  protected $options = [];
+  
+  public static function init($module, $options = []) {
+    if (!isset(self::$modules[$module])) {
+      self::$modules[$module] = new static((array) $options);
+    }
+    return self::$modules[$module];
+  }
+  
+  public static function getByFile($file) {
+    if (file_exists($file) || file_exists(__DIR__ . '/modules/' . $file)) {
+      return self::get('soil-' . basename($file, '.php'));
+    }
+    return [];
+  }
+  
+  public static function get($module) {
+    if (isset(self::$modules[$module])) {
+      return self::$modules[$module]->options;
+    }
+    if (substr($module, 0, 5)!=='soil-') {
+      return self::get('soil-' . $module);
+    }
+    return [];
+  }
+  
+  protected function __construct($options) {
+    $this->set($options);
+  }
+  
+  public function set($options) {
+    $this->options = $options;
+  }
+}
+
 function load_modules() {
   global $_wp_theme_features;
   foreach (glob(__DIR__ . '/modules/*.php') as $file) {
     $feature = 'soil-' . basename($file, '.php');
     if (isset($_wp_theme_features[$feature])) {
-      $options = (array) $_wp_theme_features[$feature];
+      Options::init($feature, $_wp_theme_features[$feature]);
       require_once $file;
     }
   }

--- a/soil.php
+++ b/soil.php
@@ -35,7 +35,7 @@ class Options {
     if (isset(self::$modules[$module])) {
       return self::$modules[$module]->options;
     }
-    if (substr($module, 0, 5)!=='soil-') {
+    if (substr($module, 0, 5) !== 'soil-') {
       return self::get('soil-' . $module);
     }
     return [];


### PR DESCRIPTION
```php
add_theme_support('soil-google-analytics', 'UA-XXXXXX');
```

By default, the script will be loaded from the `wp_footer` hook, but you can specify any other action hook as the third parameter.

```php
add_theme_support('soil-google-analytics', 'UA-XXXXXX', 'wp_head'); // script will load during wp_head
```


I also changed the way the filter works. Instead of the filter being `soil/displayGA`, it's now `soil/dummyGA` and returning `true` will use the dummy `ga()` function while `false` will load H5BP's snippet.