### PR TITLE
Pass get_search_link() to wp_redirect() closes #54

### DIFF
--- a/modules/nice-search.php
+++ b/modules/nice-search.php
@@ -12,13 +12,13 @@ namespace Roots\Soil\NiceSearch;
  */
 function redirect() {
   global $wp_rewrite;
-  if (!isset($wp_rewrite) || !is_object($wp_rewrite) || !$wp_rewrite->using_permalinks()) {
+  if (!isset($wp_rewrite) || !is_object($wp_rewrite) || !$wp_rewrite->get_search_permastruct()) {
     return;
   }
 
   $search_base = $wp_rewrite->search_base;
   if (is_search() && !is_admin() && strpos($_SERVER['REQUEST_URI'], "/{$search_base}/") === false) {
-    wp_redirect(home_url("/{$search_base}/" . urlencode(get_query_var('s'))));
+    wp_redirect(get_search_link());
     exit();
   }
 }


### PR DESCRIPTION
#54 points out that we should be using `get_search_link()`. After looking into it, it appears as though he's correct.

I also noticed that WordPress core functions all use `get_search_permastruct()` instead of  `using_permalinks()`, so I decided to copy that as well.