### PR TITLE
Mention PHP 5.4 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 A WordPress plugin which contains a collection of modules to apply theme-agnostic front-end modifications.
 
+## Requirements
+
+| Prerequisite    | How to check | How to install
+| --------------- | ------------ | ------------- |
+| PHP >= 5.4.x    | `php -v`     | [php.net](http://php.net/manual/en/install.php) |
+
 ## Installation
 
 You can install this plugin via the command-line or the WordPress admin panel.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "forum": "https://discourse.roots.io/"
   },
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.4.0",
     "composer/installers": "~1.0"
   }
 }


### PR DESCRIPTION
If we are using short syntax arrays then we should be requiring PHP 5.4 in composer and warning users in the requirements. 