### PR TITLE
Escaping remove_query_arg

### DIFF
--- a/modules/disable-asset-versioning.php
+++ b/modules/disable-asset-versioning.php
@@ -8,8 +8,8 @@ namespace Roots\Soil\DisableAssetVersioning;
  * You can enable/disable this feature in functions.php (or lib/config.php if you're using Sage):
  * add_theme_support('soil-disable-asset-versioning');
  */
-function remove_script_version($src){
-  return remove_query_arg('ver', $src);
+function remove_script_version($src) {
+  return esc_url(remove_query_arg('ver', $src));
 }
 add_filter('script_loader_src', __NAMESPACE__ . '\\remove_script_version', 15, 1);
 add_filter('style_loader_src', __NAMESPACE__ . '\\remove_script_version', 15, 1);


### PR DESCRIPTION
Escaping remove_query_arg because of new information.

https://make.wordpress.org/plugins/2015/04/20/fixing-add_query_arg-and-remove_query_arg-usage/

Also fixing spacing