### PR TITLE
Add branch alias, minimum stability and prefer stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,12 @@
   "require": {
     "php": ">=5.4.0",
     "composer/installers": "~1.0"
-  }
+  },
+  "extra": {
+      "branch-alias": {
+          "dev-master": "3.3-dev"
+      }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }


### PR DESCRIPTION
This will allow developers to test the latest version by specifying it with `3.3.*@dev` instead of `dev-master` which is considered bad practice.

The `branch-alias` should always be updated to the next version.