### PR TITLE
Properly make URLs relative when using multisite with domain mapping

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -6,11 +6,14 @@ namespace Roots\Soil\Utils;
  * Make a URL relative
  */
 function root_relative_url($input) {
-  preg_match('|(?:https?:)?//([^/]+)(/.*)|i', $input, $matches);
-  if (!isset($matches[1]) || !isset($matches[2])) {
+  $url = parse_url($input);
+  if (!isset($url['host']) || !isset($url['path'])) {
     return $input;
   }
-  if (($matches[1] === $_SERVER['SERVER_NAME']) || $matches[1] === $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT']) {
+  if (is_multisite()) {
+    $network_url = parse_url(network_site_url(), PHP_URL_HOST);
+  }
+  if (($url['host'] === $_SERVER['SERVER_NAME']) || $url['host'] === $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] || (isset($network_url) && $url['host'] === $network_url)) {
     return wp_make_link_relative($input);
   }
   return $input;


### PR DESCRIPTION
Currently when using Soil with Sage, URLs for styles and scripts being
queued through the asset pipeline use the network site url instead of a
URL mapped through a domain mapping plugin. This causes the check for
matching URLs to fail, and the asset URLs are not made relative.