### PR TITLE
Clean up to remove WP's emoji mess

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -6,6 +6,7 @@ namespace Roots\Soil\CleanUp;
  * Clean up wp_head()
  *
  * Remove unnecessary <link>'s
+ * Remove inline CSS and JS from WP emoji support
  * Remove inline CSS used by Recent Comments widget
  * Remove inline CSS used by posts with galleries
  * Remove self-closing tag and change ''s to "'s on rel_canonical()
@@ -26,6 +27,13 @@ function head_cleanup() {
   remove_action('wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0);
   remove_action('wp_head', 'wp_generator');
   remove_action('wp_head', 'wp_shortlink_wp_head', 10, 0);
+  remove_action('wp_head', 'print_emoji_detection_script', 7);
+  remove_action('admin_print_scripts', 'print_emoji_detection_script');
+  remove_action('wp_print_styles', 'print_emoji_styles');
+  remove_action('admin_print_styles', 'print_emoji_styles');
+  remove_filter('the_content_feed', 'wp_staticize_emoji');
+  remove_filter('comment_text_rss', 'wp_staticize_emoji');
+  remove_filter('wp_mail', 'wp_staticize_emoji_for_email');
 
   global $wp_widget_factory;
 


### PR DESCRIPTION
i just realized that as of wp 4.2, by default, every site now has this in the `<head>`:

```    
<script type="text/javascript">
      window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/72x72\/","ext":".png","source":{"concatemoji":"\/wp\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.2"}};
      !function(a,b,c){function d(a){var c=b.createElement("canvas"),d=c.getContext&&c.getContext("2d");return d&&d.fillText?(d.textBaseline="top",d.font="600 32px Arial","flag"===a?(d.fillText(String.fromCharCode(55356,56812,55356,56807),0,0),c.toDataURL().length>3e3):(d.fillText(String.fromCharCode(55357,56835),0,0),0!==d.getImageData(16,16,1,1).data[0])):!1}function e(a){var c=b.createElement("script");c.src=a,c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var f;c.supports={simple:d("simple"),flag:d("flag")},c.supports.simple&&c.supports.flag||(f=c.source||{},f.concatemoji?e(f.concatemoji):f.wpemoji&&f.twemoji&&(e(f.twemoji),e(f.wpemoji)))}(window,document,window._wpemojiSettings);
    </script>
    <style type="text/css">
img.wp-smiley,
img.emoji {
  display: inline !important;
  border: none !important;
  box-shadow: none !important;
  height: 1em !important;
  width: 1em !important;
  margin: 0 .07em !important;
  vertical-align: -0.1em !important;
  background: none !important;
  padding: 0 !important;
}
</style>
```

by default, WP also tries to load these custom emoji's from an external server:

![image](https://cloud.githubusercontent.com/assets/115911/7375626/9948f8a2-ed9f-11e4-97f6-e78fac0c1a92.png)

none of this is necessary for browsers that natively support emoji:

![image](https://cloud.githubusercontent.com/assets/115911/7375630/a2bbd6ac-ed9f-11e4-8fec-7936d0236284.png)
