### PR TITLE
Don't use GA logger in prod env

### DIFF
--- a/modules/google-analytics.php
+++ b/modules/google-analytics.php
@@ -13,13 +13,18 @@ function load_script() {
   $gaID = options('gaID');
   if (!$gaID) { return; }
   $loadGA = (!defined('WP_ENV') || \WP_ENV === 'production') && !current_user_can('manage_options');
+  $loadGA = apply_filters('soil/loadGA', $loadGA);
   ?>
   <script>
-    (function(s,o,i,l){s.ga=function(){s.ga.q.push(arguments);if(o['log'])o.log(i+l.call(arguments))}
-    s.ga.q=[];s.ga.l=+new Date;}(window,console,'Google Analytics: ',[].slice))
+    <?php if ($loadGA) : ?>
+      window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
+    <?php else : ?>
+      (function(s,o,i,l){s.ga=function(){s.ga.q.push(arguments);if(o['log'])o.log(i+l.call(arguments))}
+      s.ga.q=[];s.ga.l=+new Date;}(window,console,'Google Analytics: ',[].slice))
+    <?php endif; ?>
     ga('create','<?= $gaID; ?>','auto');ga('send','pageview')
   </script>
-  <?php if (apply_filters('soil/loadGA', $loadGA)) : ?>
+  <?php if ($loadGA) : ?>
     <script src="https://www.google-analytics.com/analytics.js" async defer></script>
   <?php endif; ?>
 <?php


### PR DESCRIPTION
Required a bit of opening and closing of PHP tags to keep it DRY. Let me know if it affects readability enough to justify repeating myself just a little bit.