### PR TITLE
Check for protocol relative URLs we can drop the domain from

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -6,7 +6,7 @@ namespace Roots\Soil\Utils;
  * Make a URL relative
  */
 function root_relative_url($input) {
-  preg_match('|https?://([^/]+)(/.*)|i', $input, $matches);
+  preg_match('|(?:https?:)?//([^/]+)(/.*)|i', $input, $matches);
   if (!isset($matches[1]) || !isset($matches[2])) {
     return $input;
   }


### PR DESCRIPTION
Looks like the changes from https://github.com/roots/soil/pull/49 were dropped during refactoring. 

> Changes protocol relative URLs to root relative URLs. Useful for lots of plugins such as WooCommerce that are enqueuing resources that are protocol relative.