### PR TITLE
remove page template slug from body class

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -118,12 +118,11 @@ add_filter('script_loader_tag', __NAMESPACE__ . '\\clean_script_tag');
  * Add and remove body_class() classes
  */
 function body_class($classes) {
-  // Add post/page slug if not present and template slug
+  // Add post/page slug if not present
   if (is_single() || is_page() && !is_front_page()) {
     if (!in_array(basename(get_permalink()), $classes)) {
       $classes[] = basename(get_permalink());
     }
-    $classes[] = str_replace('.php', '', basename(get_page_template()));
   }
 
   // Remove unnecessary classes


### PR DESCRIPTION
The current version of Soil inserts a body class by calling get_page_template().

get_page_template() actually returns page.php when it doesn't find a page template. It does this for everything, including posts. Soil then strips off the .php extension and inserts the class "page" where it doesn't belong. This is particularly problematic if you use .post and .page as CSS selectors, which many people do. The only page that should have the class "page" in WP is a page.

We could add a conditional check to watch for pages, or could use get_template_slug(), which doesn't fall back to page.php here, and only returns a template slug if one is set. However, I propose that we delete it completely. 

WP already outputs the page template slug as a body class, if a page template is set. It is a bit longer, but still can be used, for example page-template-template-name. This function is actually introducing unnecessary duplication in the body class, by also inserting "template-name", without the "page-template" bit. Seems unnecessary to include two classes for the same page template, unless I'm missing the use case here.