### PR TITLE
Use class full of statics to manage jQuery CDN loading

### DIFF
--- a/modules/jquery-cdn.php
+++ b/modules/jquery-cdn.php
@@ -6,11 +6,11 @@ class Fallback {
   /**
    * @var bool
    */
-  static $add_jquery_fallback = false;
+  private static $add_jquery_fallback = false;
   /**
    * @var string
    */
-  static $jquery_url;
+  private static $jquery_url;
 
   /**
    * Load jQuery from Google's CDN with a local fallback

--- a/modules/jquery-cdn.php
+++ b/modules/jquery-cdn.php
@@ -2,48 +2,80 @@
 
 namespace Roots\Soil\JqueryCDN;
 
-/**
- * Load jQuery from Google's CDN with a local fallback
- *
- * You can enable/disable this feature in functions.php (or lib/config.php if you're using Sage):
- * add_theme_support('soil-jquery-cdn');
- */
-function register_jquery() {
-  if (!is_admin()) {
-    $jquery_version = $GLOBALS['wp_scripts']->registered['jquery']->ver;
-
-    wp_deregister_script('jquery');
-
-    wp_register_script(
-      'jquery',
-      'https://ajax.googleapis.com/ajax/libs/jquery/' . $jquery_version . '/jquery.min.js',
-      [],
-      null,
-      true
-    );
-
-    add_filter('script_loader_src', __NAMESPACE__ . '\\jquery_local_fallback', 10, 2);
-  }
-}
-add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\register_jquery', 100);
-
-/**
- * Output the local fallback immediately after jQuery's <script>
- *
- * @link http://wordpress.stackexchange.com/a/12450
- */
-function jquery_local_fallback($src, $handle = null) {
+class Fallback {
+  /**
+   * @var bool
+   */
   static $add_jquery_fallback = false;
+  /**
+   * @var string
+   */
+  static $jquery_url;
 
-  if ($add_jquery_fallback) {
-    echo '<script>window.jQuery || document.write(\'<script src="' . $add_jquery_fallback .'"><\/script>\')</script>' . "\n";
-    $add_jquery_fallback = false;
+  /**
+   * Load jQuery from Google's CDN with a local fallback
+   *
+   * You can enable/disable this feature in functions.php (or lib/config.php if you're using Sage):
+   * add_theme_support('soil-jquery-cdn');
+   */
+  public static function registerJquery() {
+    if (!is_admin()) {
+      $jquery_version = $GLOBALS['wp_scripts']->registered['jquery']->ver;
+
+      wp_deregister_script('jquery');
+
+      wp_register_script(
+        'jquery',
+        'https://ajax.googleapis.com/ajax/libs/jquery/' . $jquery_version . '/jquery.min.js',
+        [],
+        null,
+        true
+      );
+
+      add_filter('script_loader_src', [__NAMESPACE__ . '\\Fallback', 'filterScripts'], 10, 2);
+    }
   }
 
-  if ($handle === 'jquery') {
-    $add_jquery_fallback = apply_filters('script_loader_src', \includes_url('/js/jquery/jquery.js'), 'jquery-fallback');
+  /**
+   * Filter enqueued scripts
+   *
+   * @param $src     string    URL of script
+   * @param $handle  string    Name of script
+   * @return mixed
+   */
+  public static function filterScripts($src, $handle)
+  {
+    if (static::$jquery_url) {
+      static::echoFallback(static::$jquery_url);
+    }
+    if ($handle === 'jquery') {
+      apply_filters('script_loader_src', includes_url('/js/jquery/jquery.js'), 'jquery-fallback');
+    }
+    if ($handle === 'jquery-fallback') {
+      static::setFallbackUrl($src);
+    }
+
+    return $src;
   }
 
-  return $src;
+  /**
+   * @param $src  string  URL of the fallback
+   */
+  public static function setFallbackUrl($src)
+  {
+    static::$add_jquery_fallback = true;
+    static::$jquery_url = $src;
+  }
+
+  /**
+   * * Output the local fallback immediately after jQuery's <script>
+   *
+   * @link  http://wordpress.stackexchange.com/a/12450
+   * @param $url  string  URl of the fallback
+   */
+  public static function echoFallback($url)
+  {
+    echo '<script>window.jQuery || document.write(\'<script src="' . $url .'"><\/script>\')</script>' . "\n";
+  }
 }
-add_action('wp_head', __NAMESPACE__ . '\\jquery_local_fallback');
+add_action('wp_enqueue_scripts', [__NAMESPACE__ . '\\Fallback', 'registerJquery'], 100);


### PR DESCRIPTION
Bit more code, but I think it's more readable and easier to comprehend. And although it's still tied to jQuery, it would be much easier to begin adding more script fallbacks and filtering more scripts this way.

Although to start filtering more scripts we would probably need to make this an actual class and not all statics.