### PR TITLE
Fix Disable Asset Ver when loaded asset is false

### DIFF
--- a/modules/disable-asset-versioning.php
+++ b/modules/disable-asset-versioning.php
@@ -9,7 +9,7 @@ namespace Roots\Soil\DisableAssetVersioning;
  * add_theme_support('soil-disable-asset-versioning');
  */
 function remove_script_version($src) {
-  return esc_url(remove_query_arg('ver', $src));
+  return $src ? esc_url(remove_query_arg('ver', $src)) : false;
 }
 add_filter('script_loader_src', __NAMESPACE__ . '\\remove_script_version', 15, 1);
 add_filter('style_loader_src', __NAMESPACE__ . '\\remove_script_version', 15, 1);


### PR DESCRIPTION
Sometimes the `$src` passed to `remove_script_version($src)` is `false`. In these instances, it should return false instead of a URL.

I noticed this in the admin panel. If I went to the plugins page, for example, it would try loading plugins.php as a stylesheet. 

This resolves that issue.