### PR TITLE
Fix warnings when input is empty in clean_style_tag

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -99,6 +99,9 @@ add_filter('language_attributes', __NAMESPACE__ . '\\language_attributes');
  */
 function clean_style_tag($input) {
   preg_match_all("!<link rel='stylesheet'\s?(id='[^']+')?\s+href='(.*)' type='text/css' media='(.*)' />!", $input, $matches);
+  if (empty($matches[2])) {
+    return $input;
+  }
   // Only display media if it is meaningful
   $media = $matches[3][0] !== '' && $matches[3][0] !== 'all' ? ' media="' . $matches[3][0] . '"' : '';
   return '<link rel="stylesheet" href="' . $matches[2][0] . '"' . $media . '>' . "\n";


### PR DESCRIPTION
If some other filter has changed $input param of style_loader_tag to empty or something other than a style tag clean_style_tag throws a warning instead of ignoring it.