### PR TITLE
Add filter soil/relative-url-filters

### DIFF
--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -13,29 +13,27 @@ use Roots\Soil\Utils;
  * You can enable/disable this feature in functions.php (or lib/config.php if you're using Sage):
  * add_theme_support('soil-relative-urls');
  */
-function enable_root_relative_urls() {
-  return !(is_admin() || preg_match('/sitemap(_index)?\.xml/', $_SERVER['REQUEST_URI']) || in_array($GLOBALS['pagenow'], ['wp-login.php', 'wp-register.php']));
+ 
+if (is_admin() || preg_match('/sitemap(_index)?\.xml/', $_SERVER['REQUEST_URI']) || in_array($GLOBALS['pagenow'], ['wp-login.php', 'wp-register.php'])) {
+  return;
 }
 
-if (enable_root_relative_urls()) {
-  $root_rel_filters = [
-    'bloginfo_url',
-    'the_permalink',
-    'wp_list_pages',
-    'wp_list_categories',
-    'wp_get_attachment_url',
-    'the_content_more_link',
-    'the_tags',
-    'get_pagenum_link',
-    'get_comment_link',
-    'month_link',
-    'day_link',
-    'year_link',
-    'term_link',
-    'the_author_posts_link',
-    'script_loader_src',
-    'style_loader_src'
-  ];
-
-  Utils\add_filters($root_rel_filters, 'Roots\\Soil\\Utils\\root_relative_url');
-}
+$root_rel_filters = apply_filters('soil/relative-url-filters', [
+  'bloginfo_url',
+  'the_permalink',
+  'wp_list_pages',
+  'wp_list_categories',
+  'wp_get_attachment_url',
+  'the_content_more_link',
+  'the_tags',
+  'get_pagenum_link',
+  'get_comment_link',
+  'month_link',
+  'day_link',
+  'year_link',
+  'term_link',
+  'the_author_posts_link',
+  'script_loader_src',
+  'style_loader_src'
+]);
+Utils\add_filters($root_rel_filters, 'Roots\\Soil\\Utils\\root_relative_url');


### PR DESCRIPTION
This will allow users to modify the filters to which the `relative-urls.php` module applies.

An example for disabling it on scripts, styles, and images would be the following:
```php
add_filter('soil/relative-url-filters', function ($filters) {
  return array_diff($filters, ['script_loader_src', 'style_loader_src', 'wp_get_attachment_url']);
});
```