### PR TITLE
Support Placeholder Links

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -46,7 +46,7 @@ class NavWalker extends \Walker_Nav_Menu {
       }
     }
 
-    $element->is_active = strpos($this->archive, $element->url);
+    $element->is_active = (!empty($element->url) && strpos($this->archive, $element->url));
 
     if ($element->is_active) {
       $element->classes[] = 'active';


### PR DESCRIPTION
HTML5 (and WordPress menus) support placeholder links. Now Soil does too.

See also: https://discourse.roots.io/t/soil-warning-nav-walker-strpos-empty-needle-when-empty-custom-link-parent-menu-element/4657