### PR TITLE
Adding .menu-item class to all <li> tags in walker

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -70,7 +70,7 @@ class NavWalker extends \Walker_Nav_Menu {
     $classes = preg_replace('/(current(-menu-|[-_]page[-_])(item|parent|ancestor))/', 'active', $classes);
     $classes = preg_replace('/^((menu|page)[-_\w+]+)+/', '', $classes);
 
-    $classes[] = 'menu-' . $slug;
+    $classes[] = 'menu-item menu-' . $slug;
 
     $classes = array_unique($classes);
 


### PR DESCRIPTION
I was thinking, it's much easier to target `.menu-item` than it is to target `> li`, and probably [more performant](http://csswizardry.com/2011/09/writing-efficient-css-selectors/) (albeit marginally so).

Was talking to the team and we all thought it wouldn't hurt to add, as the markup is still clean, but now just a little bit easier to use/work with.