### PR TITLE
Update relative-urls.php

### DIFF
--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -14,7 +14,7 @@ use Roots\Soil\Utils;
  * add_theme_support('soil-relative-urls');
  */
  
-if (is_admin() || preg_match('/sitemap(_index)?\.xml/', $_SERVER['REQUEST_URI']) || in_array($GLOBALS['pagenow'], ['wp-login.php', 'wp-register.php'])) {
+if (is_admin() || preg_match('/^\/[a-zA-Z0-9_-]sitemap(_index)?\d.xml$/', $_SERVER['REQUEST_URI']) || in_array($GLOBALS['pagenow'], ['wp-login.php', 'wp-register.php'])) {
   return;
 }
 


### PR DESCRIPTION
some sitemap plugin like yoast seo generate url for sitemap like :
http://domain.com/post-sitemap1.xml
http://domain.com/page-sitemap.xml
http://domain.com/post_tag-sitemap4.xml
...
and prev regex cannot handel this type of url and cause of error in google webmaster
the new regex fix this problem