### PR TITLE
Remove is_admin() conditional check

### DIFF
--- a/modules/jquery-cdn.php
+++ b/modules/jquery-cdn.php
@@ -9,21 +9,19 @@ namespace Roots\Soil\JqueryCDN;
  * add_theme_support('soil-jquery-cdn');
  */
 function register_jquery() {
-  if (!is_admin()) {
-    $jquery_version = $GLOBALS['wp_scripts']->registered['jquery']->ver;
+  $jquery_version = $GLOBALS['wp_scripts']->registered['jquery']->ver;
 
-    wp_deregister_script('jquery');
+  wp_deregister_script('jquery');
 
-    wp_register_script(
-      'jquery',
-      'https://ajax.googleapis.com/ajax/libs/jquery/' . $jquery_version . '/jquery.min.js',
-      [],
-      null,
-      true
-    );
+  wp_register_script(
+    'jquery',
+    'https://ajax.googleapis.com/ajax/libs/jquery/' . $jquery_version . '/jquery.min.js',
+    [],
+    null,
+    true
+  );
 
-    add_filter('script_loader_src', __NAMESPACE__ . '\\jquery_local_fallback', 10, 2);
-  }
+  add_filter('script_loader_src', __NAMESPACE__ . '\\jquery_local_fallback', 10, 2);
 }
 add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\register_jquery', 100);
 


### PR DESCRIPTION
The is_admin() is not necessary and does nothing since `wp_enqueue_scripts` is only [attached to the wp_head](https://github.com/WordPress/WordPress/blob/9fb5c540bb7888faec05670bd70a93e0593dcfb1/wp-includes/default-filters.php#L224)