### PR TITLE
Replace wp_scropts global call in modules/jquery-cdn.php

### DIFF
--- a/modules/jquery-cdn.php
+++ b/modules/jquery-cdn.php
@@ -9,7 +9,7 @@ namespace Roots\Soil\JqueryCDN;
  * add_theme_support('soil-jquery-cdn');
  */
 function register_jquery() {
-  $jquery_version = $GLOBALS['wp_scripts']->registered['jquery']->ver;
+  $jquery_version = wp_scripts()->registered['jquery']->ver;
 
   wp_deregister_script('jquery');
 


### PR DESCRIPTION
Blindly copied your [code @QWp6t](https://github.com/roots/soil/pull/137#issuecomment-172403302) and [pushed this](https://github.com/roots/soil/pull/137) without actually commiting any changes. I tried using `--amend` then, but I guess that didn't do what I wanted.

Anyway, I ended up checking out with a new branch name and trying again... 

**As for the original issue:**

<blockquote>The wp_scripts global has a safe way of being accessed by using the
wp_scripts() function.

[see here](https://github.com/WordPress/WordPress/blob/0003a004db1fa4a602dd2b0e7694d770b8962f63/wp-includes/functions.wp-scripts.php#L20)
</blockquote>

... sorry for being a dumb $hit :-1: 

Let me know if I should do something else... or if someone else wants to do it that's cool too!




