### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpcs.xml export-ignore
+/CHANGELOG.md export-ignore
+/README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,3 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpcs.xml export-ignore
-/CHANGELOG.md export-ignore
-/README.md export-ignore

--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,6 @@
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.5.1"
   },
-  "archive" : {
-    "exclude": [
-      ".editorconfig",
-      ".gitignore",
-      ".travis.yml",
-      "CONTRIBUTING.md",
-      "phpcs.xml"
-    ]
-  },
   "scripts": {
     "test": [
       "vendor/bin/phpcs --extensions=php --ignore=vendor/ -n -s ."


### PR DESCRIPTION
This way we can exclude files when installing the package with `composer install --prefer-dist`.