### PR TITLE
Disable DNS Prefetch for WordPress Emoji (WP 4.6)

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -38,6 +38,7 @@ function head_cleanup() {
   remove_filter('comment_text_rss', 'wp_staticize_emoji');
   remove_filter('wp_mail', 'wp_staticize_emoji_for_email');
   add_filter('use_default_gallery_style', '__return_false');
+  add_filter('emoji_svg_url', '__return_false');
 
   global $wp_widget_factory;
 


### PR DESCRIPTION
In WP 4.6 the new DNS Prefetch feature was added. On a typical site it looks like this:
```html
<link rel='dns-prefetch' href='//ajax.googleapis.com'>
<link rel='dns-prefetch' href='//maxcdn.bootstrapcdn.com'>
<link rel='dns-prefetch' href='//s.w.org'>
```
I was trying to determine where the *s.w.org* hostname was coming from, and tracked it down to here:
https://core.trac.wordpress.org/attachment/ticket/37387/37387.diff
```php
# src/wp-includes/general-template.php
// Add DNS prefetch for the Emoji CDN. 
// The path is removed in the foreach loop below. 
/** This filter is documented in wp-includes/formatting.php */ 
$hints['dns-prefetch'][] = apply_filters( 'emoji_svg_url', 'https://s.w.org/images/core/emoji/2/svg/' ); 
```

I've added a single line to the Soil cleanup module to disable this unnecessary DNS prefetch, and I can confirm it worked on my test site. Changing the URL to false seems to be the only way to prevent disable it.
As far as I can tell nothing else in the HEAD has changed in WP 4.6.