### PR TITLE
Enable jQuery noConflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### HEAD
+* Enable jQuery noConflict ([#160](https://github.com/roots/soil/issues/160))
+* Disable DNS Prefetch for WordPress Emoji (WP 4.6) ([#159](https://github.com/roots/soil/issues/159))
+
 ### 3.7.0: March 7th, 2016
 * Use `home_url` in `root_relative_url` ([#147](https://github.com/roots/soil/issues/147))
 * Add relative URLs to responsive images output ([#146](https://github.com/roots/soil/issues/146))

--- a/modules/jquery-cdn.php
+++ b/modules/jquery-cdn.php
@@ -34,7 +34,7 @@ function jquery_local_fallback($src, $handle = null) {
   static $add_jquery_fallback = false;
 
   if ($add_jquery_fallback) {
-    echo '<script>window.jQuery || document.write(\'<script src="' . $add_jquery_fallback .'"><\/script>\')</script>' . "\n";
+    echo '<script>(window.jQuery && jQuery.noConflict()) || document.write(\'<script src="' . $add_jquery_fallback .'"><\/script>\')</script>' . "\n";
     $add_jquery_fallback = false;
   }
 


### PR DESCRIPTION
this enables `jQuery.noConflict();` just like WP does ¯\_(ツ)_/¯

ref #155 