### PR TITLE
Replaced sanitized title with post_name fixes #161

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -57,7 +57,8 @@ class NavWalker extends \Walker_Nav_Menu {
   // @codingStandardsIgnoreEnd
 
   public function cssClasses($classes, $item) {
-    $slug = $item->post_name;
+    $menu_object_id = get_post_meta($item->ID, '_menu_item_object_id', true);
+    $slug = get_post($menu_object_id)->post_name;
 
     // Fix core `active` behavior for custom post types
     if ($this->cpt) {

--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -57,7 +57,7 @@ class NavWalker extends \Walker_Nav_Menu {
   // @codingStandardsIgnoreEnd
 
   public function cssClasses($classes, $item) {
-    $slug = sanitize_title($item->title);
+    $slug = $item->post_name;
 
     // Fix core `active` behavior for custom post types
     if ($this->cpt) {


### PR DESCRIPTION
This should resolve issue #161 as raised by @av3nger by replacing the sanitised title in menu item's CSS class name with its slug. 
Two potential issues I can see with this:
1. I'm not sure why the sanitized title was used initially, but I'm sure there probably was a reason. @retlehs any ideas?
2. Any existing theme's that update soil that currently rely on the class names of the menu items could see a (style) breaking change if this gets merged. Don't think there's anything we can do about it, just worth noting...
