### PR TITLE
Fixes PHP warnings being thrown in development

### DIFF
--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -39,8 +39,10 @@ $root_rel_filters = apply_filters('soil/relative-url-filters', [
 Utils\add_filters($root_rel_filters, 'Roots\\Soil\\Utils\\root_relative_url');
 
 add_filter('wp_calculate_image_srcset', function ($sources) {
-  foreach ($sources as $source => $src) {
-    $sources[$source]['url'] = \Roots\Soil\Utils\root_relative_url($src['url']);
+  if (is_array($sources)) {
+    foreach ($sources as $source => $src) {
+      $sources[$source]['url'] = \Roots\Soil\Utils\root_relative_url($src['url']);
+    }
   }
   return $sources;
 });

--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -39,10 +39,8 @@ $root_rel_filters = apply_filters('soil/relative-url-filters', [
 Utils\add_filters($root_rel_filters, 'Roots\\Soil\\Utils\\root_relative_url');
 
 add_filter('wp_calculate_image_srcset', function ($sources) {
-  if (is_array($sources)) {
-    foreach ($sources as $source => $src) {
-      $sources[$source]['url'] = \Roots\Soil\Utils\root_relative_url($src['url']);
-    }
+  foreach ((array) $sources as $source => $src) {
+    $sources[$source]['url'] = \Roots\Soil\Utils\root_relative_url($src['url']);
   }
   return $sources;
 });


### PR DESCRIPTION
Prevents stack trace from being dumped on the page during development.

Warning: Invalid argument supplied for foreach() in /.../public/app/plugins/soil/modules/relative-urls.php on line 44 