### PR TITLE
Add `theme_file_uri` to relative urls. WP 4.7 filter.

### DIFF
--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -34,7 +34,8 @@ $root_rel_filters = apply_filters('soil/relative-url-filters', [
   'term_link',
   'the_author_posts_link',
   'script_loader_src',
-  'style_loader_src'
+  'style_loader_src',
+  'theme_file_uri'
 ]);
 Utils\add_filters($root_rel_filters, 'Roots\\Soil\\Utils\\root_relative_url');
 


### PR DESCRIPTION
Apply relative url filter to `theme_file_uri` filter in WordPress 4.7. 

Works with `get_theme_file_uri()` method in WP 4.7.

Ex:
```php
wp_enqueue_style( 'theme-custom', get_theme_file_uri( '/assets/css/custom.css' ));
```

Will output:
```php
<link rel="stylesheet" href="http://domain.com/wp-content/themes/theme/assets/css/custom.css">
```

With `theme_file_uri` filter added to `relative-urls.php`:
```php
<link rel="stylesheet" href="/wp-content/themes/theme/assets/css/custom.css">
```

Ref: [get_theme_file_uri docs](https://developer.wordpress.org/reference/functions/get_theme_file_uri/)