### PR TITLE
Skip loading modules in the admin to prevent unintended breakage.

### DIFF
--- a/soil.php
+++ b/soil.php
@@ -54,6 +54,12 @@ require_once __DIR__ . '/lib/utils.php';
 
 function load_modules() {
   global $_wp_theme_features;
+
+  // Skip loading modules in the admin.
+  if ( is_admin() ) {
+    return;
+  }
+
   foreach (glob(__DIR__ . '/modules/*.php') as $file) {
     $feature = 'soil-' . basename($file, '.php');
     if (isset($_wp_theme_features[$feature])) {

--- a/soil.php
+++ b/soil.php
@@ -56,7 +56,7 @@ function load_modules() {
   global $_wp_theme_features;
 
   // Skip loading modules in the admin.
-  if ( is_admin() ) {
+  if (is_admin()) {
     return;
   }
 


### PR DESCRIPTION
As a developer for the AffiliateWP plugin, it was brought to our attention that there appears to be a conflict between Soil and AffiliateWP. After further inspection, the problem seems to be that y'all are loading Soil modules in the admin as well as in the front-end.

If the intent of these modules, as stated in your README are truly for front-end clean up, I can't see a good reason for loading them in the admin and possibly mucking up what, let's face it, is never going to be perfect markup in the WordPress admin.

That said, in our particular case, the 'clean-up' module is introducing a SyntaxError on one of customer's admin screens. See [AffiliateWP/2091](https://github.com/AffiliateWP/AffiliateWP/issues/2091) for more information.

Please consider merging this fix to prevent future conflicts in the admin.