### PR TITLE
Don't do `active` fix for CPT if no archive page

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -63,8 +63,10 @@ class NavWalker extends \Walker_Nav_Menu {
     if ($this->cpt) {
       $classes = str_replace('current_page_parent', '', $classes);
 
-      if (Utils\url_compare($this->archive, $item->url)) {
-        $classes[] = 'active';
+      if ($this->archive) {
+        if (Utils\url_compare($this->archive, $item->url)) {
+          $classes[] = 'active';
+        }
       }
     }
 


### PR DESCRIPTION
If the custom post type is set to not have an archive, `get_post_type_archive_link()` returns false. When that false value is provided to the `url_compare()` util function, it runs it through `trailingslashit()` which returns the string `/`, which is then less than helpful in the string comparisons to follow.

This PR just skips `url_compare()` when the CPT doesn't have an archive set. It's not able to set any class to `active` then, but that's better than setting all CPT menu items to `active`