### PR TITLE
Fix SEO Framework social image : unhook relative-url filter when necessary

### DIFF
--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -49,6 +49,9 @@ add_filter('wp_calculate_image_srcset', function ($sources) {
 /**
  * Compatibility with The SEO Framework
  */
-Utils\add_filters(['the_seo_framework_ogimage_output', 'the_seo_framework_twitterimage_output'], function ($image) {
-  return 0 === strpos($image, home_url()) ? $image : home_url($image);
+add_action('the_seo_framework_do_before_output', function () {
+  remove_filter('wp_get_attachment_url', 'Roots\\Soil\\Utils\\root_relative_url');
+});
+add_action('the_seo_framework_do_after_output', function () {
+  add_filter('wp_get_attachment_url', 'Roots\\Soil\\Utils\\root_relative_url');
 });


### PR DESCRIPTION
Fix SEO Framework social image : unhook relative-url filter during SEO Framework meta generation

Related to https://github.com/roots/soil/issues/189