### PR TITLE
Add option to anonymize IP in google analytics to become a bit more GDPR compliant

### DIFF
--- a/modules/google-analytics.php
+++ b/modules/google-analytics.php
@@ -13,7 +13,7 @@ namespace Roots\Soil\GoogleAnalytics;
  */
 function load_script() {
   $gaID = options('gaID');
-	$anomymizeIP = options('anonymizeIP');
+  $anomymizeIP = options('anonymizeIP');
   if (!$gaID) { return; }
   $loadGA = (!defined('WP_ENV') || \WP_ENV === 'production') && !current_user_can('manage_options');
   $loadGA = apply_filters('soil/loadGA', $loadGA);
@@ -26,10 +26,10 @@ function load_script() {
       s.ga.q=[];s.ga.l=+new Date;}(window,console,'Google Analytics: ',[].slice))
     <?php endif; ?>
     ga('create','<?= $gaID; ?>','auto');
-		<?php if ($anomymizeIP) : ?>
-		ga('set', 'anonymizeIp', true);
-		<?php endif; ?>
-		ga('send','pageview')
+    <?php if ($anomymizeIP) : ?>
+    ga('set', 'anonymizeIp', true);
+    <?php endif; ?>
+    ga('send','pageview')
   </script>
   <?php if ($loadGA) : ?>
     <script src="https://www.google-analytics.com/analytics.js" async defer></script>


### PR DESCRIPTION
The new GDPR law in Europe sets up new requirements on how organisations track user data. IP addresses belong to PII (personally identifiable information) and should not be tracked anymore, if not necessary. (Otherwise active consent from the user is needed).

When using GA with soil no IP anonymization was possible, now there is an option.
I am using the fork in my project, but I thought it might be of use for other users as well.

Cheers