### PR TITLE
Change to a mu-plugin when installing with Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "roots/soil",
-  "type": "wordpress-plugin",
+  "type": "wordpress-muplugin",
   "license": "MIT",
   "description": "A WordPress plugin which contains a collection of modules to apply theme-agnostic front-end modifications",
   "homepage": "https://roots.io/plugins/soil/",


### PR DESCRIPTION
I can only assume anyone who is using Soil on top of Sage 9 and installing it via Composer would ideally want it to be a mu-plugin.

I currently have it specified specifically in my `installer-paths`, but It'd be cool to not have to do that.