### PR TITLE
Move addition/removal of filters to walk function

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -23,8 +23,6 @@ class NavWalker extends \Walker_Nav_Menu {
   private $archive; // Stores the archive page for current URL
 
   public function __construct() {
-    add_filter('nav_menu_css_class', array($this, 'cssClasses'), 10, 2);
-    add_filter('nav_menu_item_id', '__return_null');
     $cpt           = get_post_type();
     $this->cpt     = in_array($cpt, get_post_types(array('_builtin' => false)));
     $this->archive = get_post_type_archive_link($cpt);
@@ -89,6 +87,23 @@ class NavWalker extends \Walker_Nav_Menu {
     $classes = array_map('trim', $classes);
 
     return array_filter($classes);
+  }
+
+  public function walk($elements, $max_depth)
+  {
+      // Add filters
+      add_filter('nav_menu_css_class', array($this, 'cssClasses'), 10, 2);
+      add_filter('nav_menu_item_id', '__return_null');
+
+      // Perform usual walk
+      $output = call_user_func_array(['parent', 'walk'], func_get_args());
+
+      // Unregister filters
+      remove_filter('nav_menu_css_class', [$this, 'cssClasses']);
+      remove_filter('nav_menu_item_id', '__return_null');
+
+      // Return result
+      return $output;
   }
 }
 

--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -89,21 +89,20 @@ class NavWalker extends \Walker_Nav_Menu {
     return array_filter($classes);
   }
 
-  public function walk($elements, $max_depth)
-  {
-      // Add filters
-      add_filter('nav_menu_css_class', array($this, 'cssClasses'), 10, 2);
-      add_filter('nav_menu_item_id', '__return_null');
+  public function walk($elements, $max_depth, ...$args) {
+    // Add filters
+    add_filter('nav_menu_css_class', array($this, 'cssClasses'), 10, 2);
+    add_filter('nav_menu_item_id', '__return_null');
 
-      // Perform usual walk
-      $output = call_user_func_array(['parent', 'walk'], func_get_args());
+    // Perform usual walk
+    $output = call_user_func_array(['parent', 'walk'], func_get_args());
 
-      // Unregister filters
-      remove_filter('nav_menu_css_class', [$this, 'cssClasses']);
-      remove_filter('nav_menu_item_id', '__return_null');
+    // Unregister filters
+    remove_filter('nav_menu_css_class', [$this, 'cssClasses']);
+    remove_filter('nav_menu_item_id', '__return_null');
 
-      // Return result
-      return $output;
+    // Return result
+    return $output;
   }
 }
 

--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -128,4 +128,3 @@ function nav_menu_args($args = '') {
   return array_merge($args, $nav_menu_args);
 }
 add_filter('wp_nav_menu_args', __NAMESPACE__ . '\\nav_menu_args');
-add_filter('nav_menu_item_id', '__return_null');


### PR DESCRIPTION
Fix #212 by removing menu-related filters after the `NavWalker` finishes performing a 'walk'

This allows for menus on a page to use different walkers independently.