### PR TITLE
Apply 'relative-url-filters' to SEO hooks

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -49,6 +49,15 @@ function add_filters($tags, $function, $priority = 10, $accepted_args = 1) {
 }
 
 /**
+ * Unhooks a single callback from multiple tags
+ */
+function remove_filters($tags, $function, $priority = 10) {
+  foreach ((array) $tags as $tag) {
+    remove_filter($tag, $function, $priority);
+  }
+}
+
+/**
  * Display error alerts in admin panel
  */
 function alerts($errors, $capability = 'activate_plugins') {

--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -18,6 +18,13 @@ if (is_admin() || isset($_GET['sitemap']) || in_array($GLOBALS['pagenow'], ['wp-
   return;
 }
 
+/**
+ * Filters that need to be removed/readded because of The SEO Framework
+ */
+const SEO_FRAMEWORK_FILTERS = [
+    'wp_get_attachment_url'
+];
+
 $root_rel_filters = apply_filters('soil/relative-url-filters', [
   'bloginfo_url',
   'the_permalink',
@@ -51,8 +58,10 @@ add_filter('wp_calculate_image_srcset', function ($sources) {
  * Compatibility with The SEO Framework
  */
 add_action('the_seo_framework_do_before_output', function () {
-  remove_filter('wp_get_attachment_url', 'Roots\\Soil\\Utils\\root_relative_url');
+  $filters = apply_filters('soil/relative-url-filters', SEO_FRAMEWORK_FILTERS);
+  Utils\remove_filters($filters, 'Roots\\Soil\\Utils\\root_relative_url');
 });
 add_action('the_seo_framework_do_after_output', function () {
-  add_filter('wp_get_attachment_url', 'Roots\\Soil\\Utils\\root_relative_url');
+  $filters = apply_filters('soil/relative-url-filters', SEO_FRAMEWORK_FILTERS);
+  Utils\add_filters($filters, 'Roots\\Soil\\Utils\\root_relative_url');
 });


### PR DESCRIPTION
Applies `soil/relative-url-filters` filter to the list of filters that are removed & added as part of #184.

This means that if hooked filters to `soil/relative-url-filters` remove `wp_get_attachment_url` then is is honoured when The SEO Framework is installed.

Fixes #217