### PR TITLE
clean_script_tag() breaks javascript from wp 5.0 core

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -92,7 +92,8 @@ add_filter('style_loader_tag', __NAMESPACE__ . '\\clean_style_tag');
  */
 function clean_script_tag($input) {
   $input = str_replace("type='text/javascript' ", '', $input);
-  return str_replace("'", '"', $input);
+  $input = str_replace('type="text/javascript" ', '', $input);
+  return $input;
 }
 add_filter('script_loader_tag', __NAMESPACE__ . '\\clean_script_tag');
 


### PR DESCRIPTION
WP 5.0 includes valid script with wp-polyfill which uses mixed single and double quotes, and is munged by clean_script_tag() to be invalid.

For reference, the exact (valid) script being affected is:
```
<script type='text/javascript'>
( 'fetch' in window ) || document.write( '<script src="/wp-includes/js/dist/vendor/wp-polyfill-fetch.min.js?ver=3.0.0"></scr' + 'ipt>' );( document.contains ) || document.write( '<script src="/wp-includes/js/dist/vendor/wp-polyfill-node-contains.min.js?ver=3.26.0-0"></scr' + 'ipt>' );( window.FormData && window.FormData.prototype.keys ) || document.write( '<script src="/wp-includes/js/dist/vendor/wp-polyfill-formdata.min.js?ver=3.0.12"></scr' + 'ipt>' );( Element.prototype.matches && Element.prototype.closest ) || document.write( '<script src="/wp-includes/js/dist/vendor/wp-polyfill-element-closest.min.js?ver=2.0.2"></scr' + 'ipt>' );
</script>
```

Fixes #216 and probably #210 and #203 as well.