### PR TITLE
Patch for NavWalker issue with WP Customizer.

### DIFF
--- a/modules/nav-walker.php
+++ b/modules/nav-walker.php
@@ -107,10 +107,22 @@ function nav_menu_args($args = '') {
   }
 
   if (!$args['walker']) {
-    $nav_menu_args['walker'] = new NavWalker();
+    $nav_menu_args['walker'] = __NAMESPACE__ . '\\NavWalker';
   }
 
   return array_merge($args, $nav_menu_args);
 }
 add_filter('wp_nav_menu_args', __NAMESPACE__ . '\\nav_menu_args');
 add_filter('nav_menu_item_id', '__return_null');
+
+// Temporary fix until WP code fixes this:
+// https://core.trac.wordpress.org/ticket/14142
+// https://wordpress.stackexchange.com/questions/295461/using-string-instead-of-object-class-instantiation-on-the-walker-argument-breaks
+function fix_custom_walkers($args) {
+  if (isset($args['walker']) && is_string($args['walker']) && class_exists($args['walker'])) {
+    $args['walker'] = new $args['walker'];
+  }
+
+  return $args;
+}
+add_filter('wp_nav_menu_args', __NAMESPACE__ . '\\fix_custom_walkers', 1001);


### PR DESCRIPTION
All navigation elements displayed using `wp_nav_menu` should be automatically available for customization via selective refresh (https://make.wordpress.org/core/2016/02/16/selective-refresh-in-the-customizer/).

Additionally, an edit icon should appear near any of these navigations (screen):

<img width="692" alt="screenshot 2019-02-07 at 08 28 27" src="https://user-images.githubusercontent.com/12466568/52396899-ba9ee980-2ab3-11e9-8868-a5ff078576c9.png">

After enabling Soil, above functionality breaks and edit icon is not applied anymore (screen):

<img width="635" alt="screenshot 2019-02-07 at 08 30 25" src="https://user-images.githubusercontent.com/12466568/52397040-3c8f1280-2ab4-11e9-96d7-da62b2ff856f.png">

It's because nav walkers should be added as class names strings instead of object instances.

Source: 
https://wordpress.stackexchange.com/questions/281854/visible-edit-shortcut-for-wordpress-menu-that-uses-nav-walker
https://make.wordpress.org/core/2015/07/29/fast-previewing-changes-to-menus-in-the-customizer/

Unfortunately because of WordPress core bug, if you try to add a class name into nav menu walkers it breaks with `Using $this when not in object context`.

Apparently, there is some confusion in track ticket: https://core.trac.wordpress.org/ticket/14142

This patch uses a workaround proposed here: https://wordpress.stackexchange.com/a/295475

After which customizer nav menus quick edit icon is back (screen):

<img width="632" alt="screenshot 2019-02-07 at 08 31 01" src="https://user-images.githubusercontent.com/12466568/52397111-8e379d00-2ab4-11e9-9c14-06583bc5db4e.png">