### PR TITLE
Fix js error, caused by replace single quotes

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -92,6 +92,13 @@ add_filter('style_loader_tag', __NAMESPACE__ . '\\clean_style_tag');
  */
 function clean_script_tag($input) {
   $input = str_replace("type='text/javascript' ", '', $input);
+  $input = \preg_replace_callback(
+    '/document.write\(\s*\'(.+)\'\s*\)/is',
+    function ($m) {
+      return str_replace($m[1], addcslashes($m[1], '"'), $m[0]);
+    },
+    $input
+  );
   return str_replace("'", '"', $input);
 }
 add_filter('script_loader_tag', __NAMESPACE__ . '\\clean_script_tag');


### PR DESCRIPTION
In some cases, script tags might contain js code document.write() with single quotes - like [wp_get_script_polyfill](https://developer.wordpress.org/reference/functions/wp_get_script_polyfill/). Replacing all single quotes lead to an SyntaxError. So add slashes in document.write arguments fixes this.