### PR TITLE
Strip '-wp' from WP jQuery version to fix #226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 * Add module for disabling the REST API ([#209](https://github.com/roots/soil/pull/209))
+* Strip '-wp' suffix from WordPress jQuery version to avoid 404 introduced in WordPress 5.2.1 ([#227](https://github.com/roots/soil/pull/227))
 
 ### 3.7.3: August 13th, 2017
 * Update method for removing recent commets widget styles ([#195](https://github.com/roots/soil/pull/195))

--- a/modules/jquery-cdn.php
+++ b/modules/jquery-cdn.php
@@ -9,7 +9,7 @@ namespace Roots\Soil\JqueryCDN;
  * add_theme_support('soil-jquery-cdn');
  */
 function register_jquery() {
-  $jquery_version = wp_scripts()->registered['jquery']->ver;
+  $jquery_version = str_replace( '-wp', '', wp_scripts()->registered['jquery']->ver );
 
   wp_deregister_script('jquery');
 


### PR DESCRIPTION
Quick fix for #226 to use str_replace to strip the undesired '-wp' suffix.