### PR TITLE
Fix Gutenberg disable-rest-api compatibility

### DIFF
--- a/modules/disable-rest-api.php
+++ b/modules/disable-rest-api.php
@@ -13,13 +13,13 @@ remove_action('template_redirect', 'rest_output_link_header', 11);
 remove_action('wp_head', 'rest_output_link_wp_head', 10);
 
 add_filter('rest_authentication_errors', function ($result) {
-    if (!empty($result)) {
-        return $result;
-    }
-  
-    if (!is_user_logged_in()) {
-        return new WP_Error('rest_not_logged_in', 'You are not currently logged in.', ['status' => 401]);
-    }
-  
+  if (!empty($result)) {
     return $result;
+  }
+
+  if (!is_user_logged_in()) {
+    return new WP_Error('rest_not_logged_in', 'You are not currently logged in.', ['status' => 401]);
+  }
+
+  return $result;
 });

--- a/modules/disable-rest-api.php
+++ b/modules/disable-rest-api.php
@@ -13,5 +13,13 @@ remove_action('template_redirect', 'rest_output_link_header', 11);
 remove_action('wp_head', 'rest_output_link_wp_head', 10);
 
 add_filter('rest_authentication_errors', function ($result) {
-  return new \WP_Error('rest_forbidden', __('REST API forbidden.', 'soil'), ['status' => rest_authorization_required_code()]);
+    if (!empty($result)) {
+        return $result;
+    }
+  
+    if (!is_user_logged_in()) {
+        return new WP_Error('rest_not_logged_in', 'You are not currently logged in.', ['status' => 401]);
+    }
+  
+    return $result;
 });


### PR DESCRIPTION
Gutenberg is using the REST-API to update content. This pull request adds a check to see if the user is logged in before restricting the API access. It basically enables Gutenberg support.

> Some security related plugins may have disabled all, or parts of, the REST API. This is used by Gutenberg to fetch all the data used to display content in the editor, so if you are missing fields, check if you have a security plugin enabled, and if it has an option for the REST API - [Marius L. J.](https://wordpress.org/support/topic/known-compatibility-issues-common-questions-and-how-to-report-bugs/#post-10552035)

This pull request fixes the following error:

![image](https://user-images.githubusercontent.com/499192/59185525-fe445580-8b70-11e9-98ea-73077996bc6d.png)
