### PR TITLE
Fix multiple times escaped (double) quotes in scripts

### DIFF
--- a/modules/clean-up.php
+++ b/modules/clean-up.php
@@ -95,7 +95,9 @@ function clean_script_tag($input) {
   $input = \preg_replace_callback(
     '/document.write\(\s*\'(.+)\'\s*\)/is',
     function ($m) {
-      return str_replace($m[1], addcslashes($m[1], '"'), $m[0]);
+      // Escape only unescaped double quotes as addcslashes would add multiple slashes
+      $script = preg_replace('/"+(?<!\\")/', '\"', $m[1]);
+      return str_replace($m[1], $script, $m[0]);
     },
     $input
   );


### PR DESCRIPTION
In #224 I've added addcslashes() to fix possible syntax errors while replacing double quotes to single quotes. Unfortunately addcslashes() would escape even `\"foo\"` to `\\"foo\\"`, which again results in js / syntax errors. Therefor it should be used stripcslashes() on the match before addcslashes() or replaced by an regex - which I went for in this PR.