### PR TITLE
fix: typo in extended options documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ add_theme_support('soil', [
 		/**
 		 * Disable recent comments CSS.
 		 */
-		'disable_rececent_comments_css',
+		'disable_recent_comments_css',
 
 		/**
 		 * Disable gallery CSS.

--- a/src/Modules/CleanUpModule.php
+++ b/src/Modules/CleanUpModule.php
@@ -84,7 +84,7 @@ class CleanUpModule extends AbstractModule
          *
          * @var bool
          */
-        'disable_rececent_comments_css' => true,
+        'disable_recent_comments_css' => true,
 
         /**
          * Disable gallery CSS.
@@ -113,7 +113,7 @@ class CleanUpModule extends AbstractModule
             'disable_emojis' => 'disableEmojis',
             'disable_gutenberg_block_css' => 'disableGutenbergBlockCss',
             'disable_extra_rss' => 'disableExtraRss',
-            'disable_rececent_comments_css' => 'disableRecentCommentsCss',
+            'disable_recent_comments_css' => 'disableRecentCommentsCss',
             'disable_gallery_css' => 'disableGalleryCss',
             'clean_html5_markup' => 'cleanHtmlMarkup',
         ];


### PR DESCRIPTION
This PR fixes a typo in the README (`disable_rececent_comments_css` instead of `disable_recent_comments_css`).