### PR TITLE
fix(module-cleanup): remove self-closing site icon meta tags

### DIFF
--- a/src/Modules/CleanUpModule.php
+++ b/src/Modules/CleanUpModule.php
@@ -227,7 +227,7 @@ class CleanUpModule extends AbstractModule
         ], 'removeSelfClosingTags');
 
         add_filter('site_icon_meta_tags', function ($meta_tags) {
-            return array_map([$this, 'site_icon_meta_tags'], $meta_tags);
+            return array_map([$this, 'removeSelfClosingTags'], $meta_tags);
         }, 20);
     }
 


### PR DESCRIPTION
This fixes issue with filtering `site_icon_meta_tags`. Previously we were attempting to pass meta tags to nonexistent method. This corrects that behavior by pointing them to the correct method.

This is still untested, though, so don't merge until it's confirmed working.

closes #258