### PR TITLE
fix(options): correctly support non-array default option

### DIFF
--- a/src/Soil.php
+++ b/src/Soil.php
@@ -131,14 +131,14 @@ class Soil
             }
 
             // add_theme_support('soil', ['module' => 'some-option'])
-            if (is_array($options) && isset($options[0]) && !isset($options[1])) {
-                $options = ['options' => $options[0]];
+            if (!is_array($options)) {
+                $options = ['options' => $options];
             }
 
             // if an option is specified,
             // let's assume the module should be enabled
             // add_theme_support('soil', ['module' => ['option' => 'value']])
-            if (! isset($options['enabled'])) {
+            if (!isset($options['enabled'])) {
                 $options['enabled'] = true;
             }
 


### PR DESCRIPTION
This resolves the noted syntax in the code comment.

This is currently only used for the GA module where the following is allowed:

```php
add_theme_support('soil', [
    'google-analytics' => 'UA-XXXXX-Y'
]);
```

It is ultimately resolved as:

```php
add_theme_support('soil', [
    'google-analytics' => [
        'enabled' => true,
        'google_analytics_id' => 'UA-XXXXX-Y'
        // the other default options are also merged
    ]
]);
```