### PR TITLE
Support checking production environment type via wp_get_environment_type()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### unreleased ###
+* Google Analytics module: support checking production environment type via `wp_get_environment_type()`
+
 ### 4.0.4: September 10th, 2020
 * Fix Google Analytics options: correctly support non-array default option
 

--- a/src/Modules/GoogleAnalyticsModule.php
+++ b/src/Modules/GoogleAnalyticsModule.php
@@ -2,6 +2,8 @@
 
 namespace Roots\Soil\Modules;
 
+use function Roots\Soil\is_production_environment;
+
 /**
  * Moves all scripts to wp_footer action
  */
@@ -94,7 +96,7 @@ class GoogleAnalyticsModule extends AbstractModule
 
         if (!$options->should_load) {
             $options->should_load = !empty($options->google_analytics_id)
-                && (!defined('WP_ENV') || \WP_ENV === 'production')
+                && is_production_environment()
                 && !current_user_can('manage_options');
         }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -61,7 +61,7 @@ function compare_base_url($base_url, $input_url, $strict_scheme = true)
  * Determine whether current environment type is production.
  *
  * WP_ENV constant predates wp_get_environment_type function (introduced in WP 5.5), so check it first.
- * See: https://github.com/roots/soil/pull/266
+ * {@see https://github.com/roots/soil/pull/266}
  *
  * Assume production as default environment type when neither WP_ENV is set nor wp_get_environment_type() is available.
  *
@@ -71,9 +71,11 @@ function is_production_environment()
 {
     if (defined('WP_ENV')) {
         return \WP_ENV === 'production';
-    } elseif (function_exists('wp_get_environment_type')) {
-        return wp_get_environment_type() === 'production';
-    } else {
-        return true;
     }
+
+    if (function_exists('wp_get_environment_type')) {
+        return wp_get_environment_type() === 'production';
+    }
+
+    return true;
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -55,3 +55,24 @@ function compare_base_url($base_url, $input_url, $strict_scheme = true)
 
     return true;
 }
+
+
+/**
+ * Determine whether current environment type is production.
+ *
+ * Use wp_get_environment_type() if available (WordPress 5.5 or newer), otherwise check whether WP_ENV constant is set.
+ *
+ * Assume production as default environment type when neither wp_get_environment_type() nor WP_ENV are available.
+ *
+ * @return bool
+ */
+function is_production_environment()
+{
+    if (function_exists('wp_get_environment_type')) {
+        return wp_get_environment_type() === 'production';
+    } else if (defined('WP_ENV')) {
+        return \WP_ENV === 'production';
+    } else {
+        return true;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -60,18 +60,19 @@ function compare_base_url($base_url, $input_url, $strict_scheme = true)
 /**
  * Determine whether current environment type is production.
  *
- * Use wp_get_environment_type() if available (WordPress 5.5 or newer), otherwise check whether WP_ENV constant is set.
+ * WP_ENV constant predates wp_get_environment_type function (introduced in WP 5.5), so check it first.
+ * See: https://github.com/roots/soil/pull/266
  *
- * Assume production as default environment type when neither wp_get_environment_type() nor WP_ENV are available.
+ * Assume production as default environment type when neither WP_ENV is set nor wp_get_environment_type() is available.
  *
  * @return bool
  */
 function is_production_environment()
 {
-    if (function_exists('wp_get_environment_type')) {
-        return wp_get_environment_type() === 'production';
-    } elseif (defined('WP_ENV')) {
+    if (defined('WP_ENV')) {
         return \WP_ENV === 'production';
+    } elseif (function_exists('wp_get_environment_type')) {
+        return wp_get_environment_type() === 'production';
     } else {
         return true;
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -70,7 +70,7 @@ function is_production_environment()
 {
     if (function_exists('wp_get_environment_type')) {
         return wp_get_environment_type() === 'production';
-    } else if (defined('WP_ENV')) {
+    } elseif (defined('WP_ENV')) {
         return \WP_ENV === 'production';
     } else {
         return true;


### PR DESCRIPTION
Fixes #265.

I've introduced new helper function for better readability, but the check could be also inlined. Perhaps the function might be deemed too specific.