### PR TITLE
Fix integration with Git Updater

### DIFF
--- a/soil.php
+++ b/soil.php
@@ -8,6 +8,7 @@
  * Author:             Roots
  * Author URI:         https://roots.io/
  * GitHub Plugin URI:  https://github.com/roots/soil
+ * Primary Branch:     main
  *
  * License:            MIT License
  * License URI:        https://opensource.org/licenses/MIT


### PR DESCRIPTION
As the default branch has been renamed from master to main, the "Primary Branch" header has to be set. See: https://github.com/afragen/git-updater/wiki/Versions-and-Branches#primary-branch