### PR TITLE
update version info [plugin reporting]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 4.0.6: July 27th, 2021
+* Fix reflected version in Wordpress Admin
+
 ### 4.0.5: July 27th, 2021
 * Fix fallback autoloader compatibility with similarly named class names in other namespaces
 * Google Analytics module: support checking production environment type via `wp_get_environment_type()`

--- a/soil.php
+++ b/soil.php
@@ -4,7 +4,7 @@
  * Plugin Name:        Soil
  * Plugin URI:         https://roots.io/plugins/soil/
  * Description:        A collection of modules to apply theme-agnostic front-end modifications to WordPress.
- * Version:            4.0.4
+ * Version:            4.0.5
  * Author:             Roots
  * Author URI:         https://roots.io/
  * GitHub Plugin URI:  https://github.com/roots/soil

--- a/soil.php
+++ b/soil.php
@@ -4,7 +4,7 @@
  * Plugin Name:        Soil
  * Plugin URI:         https://roots.io/plugins/soil/
  * Description:        A collection of modules to apply theme-agnostic front-end modifications to WordPress.
- * Version:            4.0.5
+ * Version:            4.0.6
  * Author:             Roots
  * Author URI:         https://roots.io/
  * GitHub Plugin URI:  https://github.com/roots/soil


### PR DESCRIPTION
latest tag/release for `v4.0.5` still reports version `v4.0.4` in the wordpress admin

![Screen Shot 2021-07-27 at 2 05 37 PM](https://user-images.githubusercontent.com/129784/127205377-24740317-ed8d-4bfb-a3b7-34f737a092b3.png)


updated reference