### PR TITLE
fix(module-cleanup): re-add disabling extra RSS feeds

### DIFF
--- a/src/Modules/CleanUpModule.php
+++ b/src/Modules/CleanUpModule.php
@@ -183,6 +183,7 @@ class CleanUpModule extends AbstractModule
     protected function disableExtraRss()
     {
         add_filter('feed_links_show_comments_feed', '__return_false');
+        remove_action('wp_head', 'feed_links_extra', 3);
     }
 
     /**


### PR DESCRIPTION
this is still needed to disable certain extra RSS feeds:

https://github.com/WordPress/WordPress/blob/c274d3c5204feaa5f9599e05ad69e37d77332b81/wp-includes/general-template.php#L3128-L3146