### PR TITLE
👽 Update the Google Analytics module to GA4 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 4.x.x: August 1st, 2023
+* Update the Google Analytics module to GA4
+* Remove deprecated `anonymize_ip` config from the GA module
+* Remove deprecated `optimize_id` config from the GA module
+* Add `tags` config to the GA module to create `gtag` commands
+
 ### 4.1.1: August 1st, 2022
 * Fix version number
 

--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ add_theme_support('soil', [
 
         /**
          * Additional Google Tags
-         * 
-         * @link https://developers.google.com/tag-platform/gtagjs/configure
          *
          * Format: [['key', 'value', ['optional' => 'parameters']]]
+         * 
+         * @link https://developers.google.com/tag-platform/gtagjs/configure
          */
         'tags' => [],
     ],

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ add_theme_support('soil', [
     'disable-rest-api',
     'disable-asset-versioning',
     'disable-trackbacks',
-    'google-analytics' => 'UA-XXXXX-Y',
+    'google-analytics' => 'G-XXXXXXXXXX',
     'js-to-footer',
     'nav-walker',
     'nice-search',
@@ -195,22 +195,13 @@ add_theme_support('soil', [
         'google_analytics_id' => null,
 
         /**
-         * Optimize container ID
+         * Additional Google Tags
+         * 
+         * @link https://developers.google.com/tag-platform/gtagjs/configure
          *
-         * Format: OPT-A1B2CD (previously: GTM-A1B2CD)
-         *
-         * @link https://support.google.com/optimize/answer/6262084
+         * Format: [['key', 'value', ['optional' => 'parameters']]]
          */
-        'optimize_id' => null,
-
-        /**
-         * Anonymize user IP addresses.
-         *
-         * This might be required depending on region.
-         *
-         * @link https://github.com/roots/soil/pull/206
-         */
-        'anonymize_ip',
+        'tags' => [],
     ],
 
     /**

--- a/resources/views/google-analytics.php
+++ b/resources/views/google-analytics.php
@@ -1,16 +1,19 @@
 <?php // phpcs:disable ?>
+
+<?php if (!$should_load) return; ?>
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=<?= $google_analytics_id; ?>"></script>
 <script>
-  <?php if ($should_load) : ?>
-    window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
-  <?php else : ?>
-    (function(s,o,i,l){s.ga=function(){s.ga.q.push(arguments);if(o['log'])o.log(i+l.call(arguments))}
-    s.ga.q=[];s.ga.l=+new Date;}(window,console,'Google Analytics: ',[].slice))
-  <?php endif; ?>
-  ga('create','<?= $google_analytics_id; ?>','auto');
-  <?php if ($optimize_id) : ?>ga('require','<?= $optimize_id; ?>');<?php endif; ?>
-  <?php if ($anonymize_ip) : ?>ga('set','anonymizeIp',true);<?php endif; ?>
-  ga('set','transport','beacon');ga('send','pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '<?= $google_analytics_id; ?>');
+
+  <?php foreach ($tags as $tag) : ?>
+    <?php if (!empty($tag[2])) : ?>
+      gtag(<?= $tag[0] ?>, <?= $tag[1] ?>, <?= $tag[2] ?>);
+    <?php else : ?>
+      gtag(<?= $tag[0] ?>, <?= $tag[1] ?>);
+    <?php endif; ?>
+  <?php endforeach; ?>
 </script>
-<?php if ($should_load) : ?>
-  <script src="https://www.google-analytics.com/analytics.js" async defer></script>
-<?php endif; ?>

--- a/src/Modules/GoogleAnalyticsModule.php
+++ b/src/Modules/GoogleAnalyticsModule.php
@@ -50,26 +50,15 @@ class GoogleAnalyticsModule extends AbstractModule
         'google_analytics_id' => null,
 
         /**
-         * Optimize container ID
+         * Additional Google Tags
          *
-         * Format: OPT-A1B2CD (previously: GTM-A1B2CD)
+         * Format: [['key', 'value', ['optional' => 'parameters']]]
          *
-         * @link https://support.google.com/optimize/answer/6262084
+         * @link https://developers.google.com/tag-platform/gtagjs/configure
          *
-         * @var string
+         * @var array
          */
-        'optimize_id' => null,
-
-        /**
-         * Anonymize user IP addresses.
-         *
-         * This might be required depending on region.
-         *
-         * @link https://github.com/roots/soil/pull/206
-         *
-         * @var bool
-         */
-        'anonymize_ip' => true,
+        'tags' => [],
     ];
 
     /**
@@ -98,6 +87,18 @@ class GoogleAnalyticsModule extends AbstractModule
             $options->should_load = !empty($options->google_analytics_id)
                 && is_production_environment()
                 && !current_user_can('manage_options');
+        }
+
+        if (!empty($options->tags)) {
+            $options->tags = array_map(function ($tag) {
+                return array_map(function ($value) {
+                    if (is_array($value)) {
+                        return json_encode($value);
+                    }
+
+                    return "'{$value}'";
+                }, $tag);
+            }, $options->tags);
         }
 
         return $options;

--- a/src/Modules/GoogleAnalyticsModule.php
+++ b/src/Modules/GoogleAnalyticsModule.php
@@ -93,7 +93,7 @@ class GoogleAnalyticsModule extends AbstractModule
             $options->tags = array_map(function ($tag) {
                 return array_map(function ($value) {
                     if (is_array($value)) {
-                        return json_encode($value);
+                        return wp_json_encode($value);
                     }
 
                     return "'{$value}'";


### PR DESCRIPTION
Pushing this up in response to [discourse](https://discourse.roots.io/t/soil-plugin-google-analytics-module-uses-obsolete-universal-analytics-loader/25741).

This updates the Google Analytics module to GA4. The `anonymize_ip` and `optimize_id` config options have been removed and `tags` has been added to allow configuring custom [gtag commands](https://developers.google.com/tag-platform/gtagjs/configure).

```php
'google-analytics' => [
    'should_load' => true,
    'google_analytics_id' => 'G-XXXXXXXXXX',
    'tags' => [
        ['config', 'test', ['example' => 'value']],
        ['event', ['send' => 'pageview']],
    ],
],
```

would output:

```html
<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'G-XXXXXXXXXX');

  gtag('config', 'test', {"example":"value"});
  gtag('event', {"send":"pageview"});
</script>
```

### Note

Might be worth exploring renaming the module since GA4 is tied into GTM? 🤷 Not that big of a deal, though.

## Todo

- [ ] Update `soil.php` plugin version.
- [ ] Update `CHANGELOG.md` version.
- [ ] Decide on release version (not sure what you want to bump the version too with it being a "breaking change")
- [ ] Add back `defer`?

## Change log

### Enhancements 

- 👽 Update the Google Analytics module to GA4
- 🔥 Remove deprecated `anonymize_ip` config from the GA module
- 🔥 Remove deprecated `optimize_id` config from the GA module
- ✨ Add `tags` config to the GA module to create `gtag` commands